### PR TITLE
esc cleanup and make CAN read not block loop()

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -85,3 +85,6 @@ Settings for esc
 
 // For BMS on canbus, else comment out
 // #define BMS_CAN_ID 10
+
+#define CAN_INTERVAL 30  // milliseconds, minimum time between data requests, prevent hammering the bus
+#define CAN_TIMEOUT 1000 // milliseconds, how long until we give up and try to request data again

--- a/src/esc.cpp
+++ b/src/esc.cpp
@@ -5,28 +5,53 @@ void ESC::setup()
   CAN.setPins(CAN_RX_PIN, CAN_TX_PIN);
   // start the CAN bus at 500 kbps
   CAN.begin(500E3);
-
-  // For testing
-  getBalance();
 }
 
 void ESC::loop()
 {
-  getRealtimeData();
-  getBalance();
+  if (!requestSent)
+    sendNextRequest();
+  else
+    readCAN();
+}
+
+void ESC::sendNextRequest()
+{
+  if (lastRequestMillis + CAN_INTERVAL > millis())
+    return; // don't do anything until CAN_INTERVAL elapsed
+
+  step++;
+  switch (step)
+  {
+  case 1:
+    getRealtimeData();
+    break;
+  case 2:
+    getBalance();
+    break;
 #ifdef BMS_CAN_ID
-  getBMS();
+  case 3:
+    getBMS();
+    break;
 #endif
+  default:
+    step = 0;
+    return;
+  }
+  requestSent = true;
+  lastRequestMillis = millis();
 }
 
 void ESC::getRealtimeData()
 {
+  requestID = 0x32;
+  expectedLength = 18;
   struct can_frame canMsg1;
   canMsg1.can_id = (uint16_t(CAN_PACKET_PROCESS_SHORT_BUFFER) << 8) + ESC_CAN_ID;
   canMsg1.can_dlc = 0x07;
   canMsg1.data[0] = BALANCE_BUDDY_CAN_ID;
   canMsg1.data[1] = 0x00;
-  canMsg1.data[2] = 0x32;
+  canMsg1.data[2] = requestID;
   canMsg1.data[3] = 0x00;
   canMsg1.data[4] = 0x00;
   canMsg1.data[5] = B10000001;
@@ -35,17 +60,118 @@ void ESC::getRealtimeData()
   CAN.beginExtendedPacket(canMsg1.can_id, canMsg1.can_dlc);
   CAN.write(canMsg1.data, canMsg1.can_dlc);
   CAN.endPacket();
+}
 
-  batchRead();
-  parseRealtimeData();
+void ESC::getBalance()
+{
+  requestID = 0x4F;
+  expectedLength = 37;
+  struct can_frame canMsg1;
+  canMsg1.can_id = (uint16_t(CAN_PACKET_PROCESS_SHORT_BUFFER) << 8) + ESC_CAN_ID;
+  canMsg1.can_dlc = 0x03;
+  canMsg1.data[0] = BALANCE_BUDDY_CAN_ID;
+  canMsg1.data[1] = 0x00;
+  canMsg1.data[2] = requestID;
+
+  CAN.beginExtendedPacket(canMsg1.can_id, canMsg1.can_dlc);
+  CAN.write(canMsg1.data, canMsg1.can_dlc);
+  CAN.endPacket();
+}
+
+#ifdef BMS_CAN_ID
+void ESC::getBMS()
+{
+  requestID = 0x04;
+  expectedLength = 50;
+  struct can_frame canMsg1;
+  canMsg1.can_id = (uint16_t(CAN_PACKET_PROCESS_SHORT_BUFFER) << 8) + BMS_CAN_ID;
+  canMsg1.can_dlc = 0x03;
+  canMsg1.data[0] = BALANCE_BUDDY_CAN_ID;
+  canMsg1.data[1] = 0x00;
+  canMsg1.data[2] = requestID;
+
+  CAN.beginExtendedPacket(canMsg1.can_id, canMsg1.can_dlc);
+  CAN.write(canMsg1.data, canMsg1.can_dlc);
+  CAN.endPacket();
+}
+#endif
+
+void ESC::startOver()
+{
+  readBufferLength = 0;
+  std::fill(readBuffer, readBuffer + 50, 0);
+  readBufferInfoLength = 0;
+  std::fill(readBufferInfo, readBufferInfo + 8, 0);
+  supposedLength = 0;
+  requestSent = false;
+}
+
+void ESC::readCAN()
+{
+  int packetSize = CAN.parsePacket();
+  while (packetSize)
+  {
+    currentPacket.can_id = CAN.packetId();
+    currentPacket.can_dlc = packetSize;
+    for (int i = 0; i < packetSize; i++)
+      currentPacket.data[i] = CAN.read();
+
+    // printFrame(&currentPacket); // for debugging
+    if (currentPacket.can_id == ((uint16_t)CAN_PACKET_FILL_RX_BUFFER << 8) + BALANCE_BUDDY_CAN_ID)
+    {
+      for (int j = 1; j < currentPacket.can_dlc; j++)
+      {
+        readBuffer[currentPacket.data[0] + j - 1] = currentPacket.data[j];
+        readBufferLength++;
+      }
+    }
+    else if (currentPacket.can_id == ((uint16_t)CAN_PACKET_PROCESS_RX_BUFFER << 8) + BALANCE_BUDDY_CAN_ID)
+    {
+      for (int j = 0; j < currentPacket.can_dlc; j++)
+      {
+        readBufferInfo[j] = currentPacket.data[j];
+        readBufferInfoLength++;
+      }
+    }
+    packetSize = CAN.parsePacket();
+  }
+
+  if (readBufferInfoLength && !supposedLength)
+    supposedLength = ((uint16_t)readBufferInfo[2] << 8) + readBufferInfo[3];
+
+  // TODO: Proper read validation with checksum, for now we just compare lengths, can improve if data is error prone.
+  if (supposedLength && readBufferLength == supposedLength)
+  {
+    if (readBufferLength == expectedLength && readBuffer[0] == requestID)
+      parseRequest();
+    startOver();
+  }
+  else if (supposedLength && readBufferLength > supposedLength) // this means something is wrong and we got too much data
+    startOver();
+  else if (lastRequestMillis + CAN_TIMEOUT < millis()) // give up and start over
+    startOver();
+}
+
+void ESC::parseRequest()
+{
+  switch (step)
+  {
+  case 1:
+    parseRealtimeData();
+    break;
+  case 2:
+    parseBalance();
+    break;
+#ifdef BMS_CAN_ID
+  case 3:
+    parseBMS();
+    break;
+#endif
+  }
 }
 
 void ESC::parseRealtimeData()
 {
-  if (readBufferLength != 0x12 || readBuffer[0] != 0x32)
-  {
-    return;
-  }
   tempMosfet = read_double_2(5, 10);
   tempMotor = read_double_2(7, 10);
   dutyCycle = read_double_2(9, 1000);
@@ -53,41 +179,16 @@ void ESC::parseRealtimeData()
   voltage = read_double_2(15, 10);
   fault = read_uint8(17);
   convert_erpm();
-
-  //  Serial.print("Mosfet Temp: ");
-  //  Serial.print(tempMosfet);
-  //  Serial.println();
-  //  Serial.print("voltage: ");
-  //  Serial.print(voltage);
-  //  Serial.println();
-  //  Serial.print("faultoll: ");
-  //  Serial.print(fault);
-  //  Serial.println();
 }
 
-void ESC::getBalance()
+void ESC::convert_erpm()
 {
-  struct can_frame canMsg1;
-  canMsg1.can_id = (uint16_t(CAN_PACKET_PROCESS_SHORT_BUFFER) << 8) + ESC_CAN_ID;
-  canMsg1.can_dlc = 0x03;
-  canMsg1.data[0] = BALANCE_BUDDY_CAN_ID;
-  canMsg1.data[1] = 0x00;
-  canMsg1.data[2] = 0x4F;
-
-  CAN.beginExtendedPacket(canMsg1.can_id, canMsg1.can_dlc);
-  CAN.write(canMsg1.data, canMsg1.can_dlc);
-  CAN.endPacket();
-
-  batchRead();
-  parseBalance();
+  rpm = erpm / (MOTOR_POLES / 2);
+  speed_ms = rpm * WHEEL_DIAMETER_MM * PI / 1000 / 60;
 }
 
 void ESC::parseBalance()
 {
-  if (readBufferLength != 0x25 || readBuffer[0] != 0x4F)
-  {
-    return;
-  }
   pidOutput = read_double_4(1, 1000000);
   pitch = read_double_4(5, 1000000);
   roll = read_double_4(9, 1000000);
@@ -98,41 +199,11 @@ void ESC::parseBalance()
   switchState = read_uint16(27);
   adc1 = read_double_4(29, 1000000);
   adc2 = read_double_4(33, 1000000);
-  //  Serial.print("PID Output: ");
-  //  Serial.print(pidOutput);
-  //  Serial.println();
-  //  Serial.print("Pitch: ");
-  //  Serial.print(pitch);
-  //  Serial.println();
-  //  Serial.print("Roll: ");
-  //  Serial.print(roll);
-  //  Serial.println();
 }
 
 #ifdef BMS_CAN_ID
-void ESC::getBMS()
-{
-  struct can_frame canMsg1;
-  canMsg1.can_id = (uint16_t(CAN_PACKET_PROCESS_SHORT_BUFFER) << 8) + BMS_CAN_ID;
-  canMsg1.can_dlc = 0x03;
-  canMsg1.data[0] = BALANCE_BUDDY_CAN_ID;
-  canMsg1.data[1] = 0x00;
-  canMsg1.data[2] = 0x04;
-
-  CAN.beginExtendedPacket(canMsg1.can_id, canMsg1.can_dlc);
-  CAN.write(canMsg1.data, canMsg1.can_dlc);
-  CAN.endPacket();
-
-  batchRead();
-  parseBMS();
-}
-
 void ESC::parseBMS()
 {
-  if (readBufferLength != 0x32 || readBuffer[0] != 0x04)
-  {
-    return;
-  }
   packVoltage = read_double_4(1, 1000);
   packCurrent = read_double_4(5, 1000);
   packSoC = read_uint8(9);
@@ -141,15 +212,6 @@ void ESC::parseBMS()
   cellVoltageLow = read_double_4(18, 1000);
   cellVoltageMisMatch = read_double_4(22, 1000);
   // there's more that I don't feel like adding now
-
-  //  Serial.println("BMS Data:");
-  //  Serial.println(packVoltage);
-  //  Serial.println(packCurrent);
-  //  Serial.println(packSoC);
-  //  Serial.println(cellVoltageHigh);
-  //  Serial.println(cellVoltageAverage);
-  //  Serial.println(cellVoltageLow);
-  //  Serial.println(cellVoltageMisMatch);
 }
 #endif
 
@@ -160,26 +222,26 @@ uint8_t ESC::read_uint8(uint8_t pos)
 
 uint16_t ESC::read_uint16(uint8_t pos)
 {
-  return ((uint16_t)readBuffer[pos] << 8) + ((uint16_t)readBuffer[pos+1]);
+  return ((uint16_t)readBuffer[pos] << 8) + ((uint16_t)readBuffer[pos + 1]);
 }
 
 uint32_t ESC::read_uint32(uint8_t pos)
 {
-  return ((uint32_t)readBuffer[pos] << 24) + ((uint32_t)readBuffer[pos+1] << 16) + ((uint32_t)readBuffer[pos+2] << 8) + ((uint32_t)readBuffer[pos+3]);
+  return ((uint32_t)readBuffer[pos] << 24) + ((uint32_t)readBuffer[pos + 1] << 16) + ((uint32_t)readBuffer[pos + 2] << 8) + ((uint32_t)readBuffer[pos + 3]);
 }
 
 double ESC::read_double_2(uint8_t pos, double scale)
 {
   if (scale == 0.0)
     scale = 1.0;
-  return int16_t(((int16_t)readBuffer[pos] << 8) + ((int16_t)readBuffer[pos+1])) / scale;
+  return int16_t(((int16_t)readBuffer[pos] << 8) + ((int16_t)readBuffer[pos + 1])) / scale;
 }
 
 double ESC::read_double_4(uint8_t pos, double scale)
 {
   if (scale == 0.0)
     scale = 1.0;
-  return (((int32_t)readBuffer[pos] << 24) + ((int32_t)readBuffer[pos+1] << 16) + ((int32_t)readBuffer[pos+2] << 8) + ((int32_t)readBuffer[pos+3])) / scale;
+  return (((int32_t)readBuffer[pos] << 24) + ((int32_t)readBuffer[pos + 1] << 16) + ((int32_t)readBuffer[pos + 2] << 8) + ((int32_t)readBuffer[pos + 3])) / scale;
 }
 
 void ESC::printFrame(struct can_frame *frame)
@@ -194,87 +256,4 @@ void ESC::printFrame(struct can_frame *frame)
     Serial.print(" ");
   }
   Serial.println();
-}
-
-void ESC::batchRead()
-{
-
-  responsesLength = 0;
-  for (int j = 0; j < 1000 && responsesLength < 10; j++)
-  {
-    int packetSize = CAN.parsePacket();
-    if (packetSize)
-    {
-      responses[responsesLength].can_id = CAN.packetId();
-      responses[responsesLength].can_dlc = packetSize;
-      for (int i = 0; i < packetSize; i++)
-      {
-        responses[responsesLength].data[i] = CAN.read();
-      }
-      responsesLength++;
-    }
-    delayMicroseconds(10);
-  }
-
-  //  for(int i = 0; i < responsesLength; i++){
-  //    printFrame(&responses[i]);
-  //  }
-
-  // Clear buffer
-  readBufferLength = 0;
-  for (int i = 0; i < 50; i++)
-  {
-    readBuffer[i] = 0; //(Not really necessary ?)
-  }
-  readBufferInfoLength = 0;
-  for (int i = 0; i < 8; i++)
-  {
-    readBufferInfo[i] = 0; //(Not really necessary ?)
-  }
-  // Convert can frames to full buffer
-  for (int i = 0; i < responsesLength; i++)
-  {
-    if (responses[i].can_id == ((uint16_t)CAN_PACKET_FILL_RX_BUFFER << 8) + BALANCE_BUDDY_CAN_ID)
-    {
-      for (int j = 1; j < responses[i].can_dlc; j++)
-      {
-        readBuffer[responses[i].data[0] + j - 1] = responses[i].data[j];
-        readBufferLength++;
-      }
-    }
-    else if (responses[i].can_id == ((uint16_t)CAN_PACKET_PROCESS_RX_BUFFER << 8) + BALANCE_BUDDY_CAN_ID)
-    {
-      for (int j = 0; j < responses[i].can_dlc; j++)
-      {
-        readBufferInfo[j] = responses[i].data[j];
-        readBufferInfoLength++;
-      }
-    }
-  }
-
-  //  for(int i = 0; i < readBufferLength; i++){
-  //    Serial.print(readBuffer[i],HEX);
-  //    Serial.print(" ");
-  //  }
-  //  Serial.println();
-  //
-  //  for(int i = 0; i < readBufferInfoLength; i++){
-  //    Serial.print(readBufferInfo[i],HEX);
-  //    Serial.print(" ");
-  //  }
-  //  Serial.println();
-
-  // TODO: Proper read validation with checksum, for now we just compare lengths, can improove if data is error prone.
-  uint16_t supposedLength = ((uint16_t)readBufferInfo[2] << 8) + readBufferInfo[3];
-  if (readBufferLength != supposedLength)
-  {
-    readBufferLength = 0;
-    readBufferInfoLength = 0;
-  }
-}
-
-void ESC::convert_erpm()
-{
-  rpm = erpm / (MOTOR_POLES / 2);
-  speed_ms = rpm * WHEEL_DIAMETER_MM * PI / 1000 / 60;
 }

--- a/src/esc.cpp
+++ b/src/esc.cpp
@@ -46,12 +46,12 @@ void ESC::parseRealtimeData()
   {
     return;
   }
-  tempMosfet = (((int16_t)readBuffer[5] << 8) + ((int16_t)readBuffer[6])) / 10.0;
-  tempMotor = (((int16_t)readBuffer[7] << 8) + ((int16_t)readBuffer[8])) / 10.0;
-  dutyCycle = int16_t(((int16_t)readBuffer[9] << 8) + ((int16_t)readBuffer[10])) / 1000.0;
-  erpm = (((int32_t)readBuffer[11] << 24) + ((int32_t)readBuffer[12] << 16) + ((int32_t)readBuffer[13] << 8) + ((int32_t)readBuffer[14]));
-  voltage = (((int16_t)readBuffer[15] << 8) + ((int16_t)readBuffer[16])) / 10.0;
-  fault = readBuffer[17];
+  tempMosfet = read_double_2(5, 10);
+  tempMotor = read_double_2(7, 10);
+  dutyCycle = read_double_2(9, 1000);
+  erpm = read_double_4(11, 1);
+  voltage = read_double_2(15, 10);
+  fault = read_uint8(17);
   convert_erpm();
 
   //  Serial.print("Mosfet Temp: ");
@@ -88,16 +88,16 @@ void ESC::parseBalance()
   {
     return;
   }
-  pidOutput = (((int32_t)readBuffer[1] << 24) + ((int32_t)readBuffer[2] << 16) + ((int32_t)readBuffer[3] << 8) + ((int32_t)readBuffer[4])) / 1000000.0;
-  pitch = (((int32_t)readBuffer[5] << 24) + ((int32_t)readBuffer[6] << 16) + ((int32_t)readBuffer[7] << 8) + ((int32_t)readBuffer[8])) / 1000000.0;
-  roll = (((int32_t)readBuffer[9] << 24) + ((int32_t)readBuffer[10] << 16) + ((int32_t)readBuffer[11] << 8) + ((int32_t)readBuffer[12])) / 1000000.0;
-  loopTime = ((uint32_t)readBuffer[13] << 24) + ((uint32_t)readBuffer[14] << 16) + ((uint32_t)readBuffer[15] << 8) + ((uint32_t)readBuffer[16]);
-  motorCurrent = (((int32_t)readBuffer[17] << 24) + ((int32_t)readBuffer[18] << 16) + ((int32_t)readBuffer[19] << 8) + ((int32_t)readBuffer[20])) / 1000000.0;
-  motorPosition = (((int32_t)readBuffer[21] << 24) + ((int32_t)readBuffer[22] << 16) + ((int32_t)readBuffer[23] << 8) + ((int32_t)readBuffer[24])) / 1000000.0;
-  balanceState = ((uint16_t)readBuffer[25] << 8) + ((uint16_t)readBuffer[26]);
-  switchState = ((uint16_t)readBuffer[27] << 8) + ((uint16_t)readBuffer[28]);
-  adc1 = (((int32_t)readBuffer[29] << 24) + ((int32_t)readBuffer[30] << 16) + ((int32_t)readBuffer[31] << 8) + ((int32_t)readBuffer[32])) / 1000000.0;
-  adc2 = (((int32_t)readBuffer[33] << 24) + ((int32_t)readBuffer[34] << 16) + ((int32_t)readBuffer[35] << 8) + ((int32_t)readBuffer[36])) / 1000000.0;
+  pidOutput = read_double_4(1, 1000000);
+  pitch = read_double_4(5, 1000000);
+  roll = read_double_4(9, 1000000);
+  loopTime = read_uint32(13);
+  motorCurrent = read_double_4(17, 1000000);
+  motorPosition = read_double_4(21, 1000000);
+  balanceState = read_uint16(25);
+  switchState = read_uint16(27);
+  adc1 = read_double_4(29, 1000000);
+  adc2 = read_double_4(33, 1000000);
   //  Serial.print("PID Output: ");
   //  Serial.print(pidOutput);
   //  Serial.println();
@@ -133,13 +133,13 @@ void ESC::parseBMS()
   {
     return;
   }
-  packVoltage = (((int32_t)readBuffer[1] << 24) + ((int32_t)readBuffer[2] << 16) + ((int32_t)readBuffer[3] << 8) + ((int32_t)readBuffer[4])) / 1000.0;
-  packCurrent = (((int32_t)readBuffer[5] << 24) + ((int32_t)readBuffer[6] << 16) + ((int32_t)readBuffer[7] << 8) + ((int32_t)readBuffer[8])) / 1000.0;
-  packSoC = (uint8_t)readBuffer[9];
-  cellVoltageHigh = (((int32_t)readBuffer[10] << 24) + ((int32_t)readBuffer[11] << 16) + ((int32_t)readBuffer[12] << 8) + ((int32_t)readBuffer[13])) / 1000.0;
-  cellVoltageAverage = (((int32_t)readBuffer[14] << 24) + ((int32_t)readBuffer[15] << 16) + ((int32_t)readBuffer[16] << 8) + ((int32_t)readBuffer[17])) / 1000.0;
-  cellVoltageLow = (((int32_t)readBuffer[18] << 24) + ((int32_t)readBuffer[19] << 16) + ((int32_t)readBuffer[20] << 8) + ((int32_t)readBuffer[21])) / 1000.0;
-  cellVoltageMisMatch = (((int32_t)readBuffer[22] << 24) + ((int32_t)readBuffer[23] << 16) + ((int32_t)readBuffer[24] << 8) + ((int32_t)readBuffer[25])) / 1000.0;
+  packVoltage = read_double_4(1, 1000);
+  packCurrent = read_double_4(5, 1000);
+  packSoC = read_uint8(9);
+  cellVoltageHigh = read_double_4(10, 1000);
+  cellVoltageAverage = read_double_4(14, 1000);
+  cellVoltageLow = read_double_4(18, 1000);
+  cellVoltageMisMatch = read_double_4(22, 1000);
   // there's more that I don't feel like adding now
 
   //  Serial.println("BMS Data:");
@@ -152,6 +152,35 @@ void ESC::parseBMS()
   //  Serial.println(cellVoltageMisMatch);
 }
 #endif
+
+uint8_t ESC::read_uint8(uint8_t pos)
+{
+  return readBuffer[pos];
+}
+
+uint16_t ESC::read_uint16(uint8_t pos)
+{
+  return ((uint16_t)readBuffer[pos] << 8) + ((uint16_t)readBuffer[pos+1]);
+}
+
+uint32_t ESC::read_uint32(uint8_t pos)
+{
+  return ((uint32_t)readBuffer[pos] << 24) + ((uint32_t)readBuffer[pos+1] << 16) + ((uint32_t)readBuffer[pos+2] << 8) + ((uint32_t)readBuffer[pos+3]);
+}
+
+double ESC::read_double_2(uint8_t pos, double scale)
+{
+  if (scale == 0.0)
+    scale = 1.0;
+  return int16_t(((int16_t)readBuffer[pos] << 8) + ((int16_t)readBuffer[pos+1])) / scale;
+}
+
+double ESC::read_double_4(uint8_t pos, double scale)
+{
+  if (scale == 0.0)
+    scale = 1.0;
+  return (((int32_t)readBuffer[pos] << 24) + ((int32_t)readBuffer[pos+1] << 16) + ((int32_t)readBuffer[pos+2] << 8) + ((int32_t)readBuffer[pos+3])) / scale;
+}
 
 void ESC::printFrame(struct can_frame *frame)
 {

--- a/src/esc.h
+++ b/src/esc.h
@@ -90,6 +90,12 @@ private:
 
   void convert_erpm();
 
+  uint8_t read_uint8(uint8_t pos);
+  uint16_t read_uint16(uint8_t pos);
+  uint32_t read_uint32(uint8_t pos);
+  double read_double_2(uint8_t pos, double scale);
+  double read_double_4(uint8_t pos, double scale);
+
 public:
   // RT Data vars
   double tempMosfet;

--- a/src/esc.h
+++ b/src/esc.h
@@ -62,33 +62,37 @@ private:
     unsigned char data[8] __attribute__((aligned(8)));
   };
 
-  struct can_frame responses[10];
-  int responsesLength = 0;
+  struct can_frame currentPacket;
 
   uint8_t readBuffer[50];
   uint8_t readBufferLength = 0;
   uint8_t readBufferInfo[8];
   uint8_t readBufferInfoLength = 0;
 
+  bool requestSent = false;
+  uint8_t step = 0;
+  long lastRequestMillis = 0;
+  unsigned char requestID;
+  uint16_t expectedLength;
+  uint16_t supposedLength = 0;
+
+  void sendNextRequest();
   void getRealtimeData();
-
-  void parseRealtimeData();
-
   void getBalance();
 
+  void parseRequest();
+  void parseRealtimeData();
   void parseBalance();
+  void convert_erpm();
 
 #ifdef BMS_CAN_ID
   void getBMS();
-
   void parseBMS();
 #endif
 
+  void startOver();
+  void readCAN();
   void printFrame(struct can_frame *frame);
-
-  void batchRead();
-
-  void convert_erpm();
 
   uint8_t read_uint8(uint8_t pos);
   uint16_t read_uint16(uint8_t pos);


### PR DESCRIPTION
This separates CAN read from the process loop, to speed up the loop and add a configurable interval to CAN data requests.

This buffers the data bit by bit each loop, as it's available. It then parses the data as soon as it reaches expected length, but offers a timeout in case some data is missed.